### PR TITLE
Fixed 'sort of' grammar error

### DIFF
--- a/locales/nl-NL.json
+++ b/locales/nl-NL.json
@@ -1,6 +1,6 @@
 [
   "nu net",
-  "%s seconde geleden",
+  ["%s seconde geleden", "%s seconden geleden"],
   ["%s minuut geleden", "%s minuten geleden"],
   "%s uur geleden",
   ["%s dag geleden", "%s dagen geleden"],

--- a/locales/nl-NL.json
+++ b/locales/nl-NL.json
@@ -1,10 +1,10 @@
 [
   "nu net",
-  ["%s seconde geleden", "%s seconde geleden"],
+  "%s seconde geleden",
   ["%s minuut geleden", "%s minuten geleden"],
-  ["%s uur geleden", "%s uur geleden"],
+  "%s uur geleden",
   ["%s dag geleden", "%s dagen geleden"],
   ["%s week geleden", "%s weken geleden"],
   ["%s maand geleden", "%s maanden geleden"],
-  ["%s jaar geleden", "%s jaar geleden"]
+  "%s jaar geleden"
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-timeago",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "productName": "Vue Timeago",
   "description": "A timeago filter for Vue.",
   "license": "MIT",


### PR DESCRIPTION
There are multiple ways of spelling seconds in dutch, the old way and the new one, updated this to the 'new' spelling rule. Although both are correct, this is a bit more modern.