### PR TITLE
Add CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,8 @@
 $ npm install --save vue-timeago
 ```
 
-### CDN
+CDN: [UNPKG](https://unpkg.com/vue-timeago/dist/) | [jsDelivr](https://cdn.jsdelivr.net/npm/vue-timeago/dist/) (available as `window.VueTimeago`)
 
-```html
-<script src="https://cdn.jsdelivr.net/npm/vue-timeago@3/dist/vue-timeago.min.js"></script>
-<!-- or -->
-<script src="https://unpkg.com/vue-timeago@3/dist/vue-timeago.js"></script>
-```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@
 $ npm install --save vue-timeago
 ```
 
-It's also available on NPMCDN: https://unpkg.com/vue-timeago/
+### CDN
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/vue-timeago@3/dist/vue-timeago.min.js"></script>
+<!-- or -->
+<script src="https://unpkg.com/vue-timeago@3/dist/vue-timeago.js"></script>
+```
 
 ## Usage
 


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/vue-timeago) to your readme as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg, but offers a larger network and better reliability.