### PR TITLE
Show actual time in title while maxTime has not passed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,17 @@ export default function install(
       sinceTime() {
         return new Date(this.since).getTime()
       },
+      timeForTitle() {
+        const seconds = this.now / 1000 - this.sinceTime / 1000
+
+        if (this.maxTime && seconds > this.maxTime) {
+          return '';
+        }
+
+        return this.format
+          ? this.format(this.sinceTime)
+          : formatTime(this.sinceTime)
+      },
       timeago() {
         const seconds = this.now / 1000 - this.sinceTime / 1000
 
@@ -103,7 +114,8 @@ export default function install(
         'time',
         {
           attrs: {
-            datetime: new Date(this.since)
+            datetime: new Date(this.since),
+            title: this.timeForTitle,
           }
         },
         this.timeago

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ export default function install(
         const seconds = this.now / 1000 - this.sinceTime / 1000
 
         if (this.maxTime && seconds > this.maxTime) {
-          return ''
+          return null
         }
 
         return this.format

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ export default function install(
         const seconds = this.now / 1000 - this.sinceTime / 1000
 
         if (this.maxTime && seconds > this.maxTime) {
-          return '';
+          return ''
         }
 
         return this.format
@@ -115,7 +115,7 @@ export default function install(
         {
           attrs: {
             datetime: new Date(this.since),
-            title: this.timeForTitle,
+            title: this.timeForTitle
           }
         },
         this.timeago


### PR DESCRIPTION
This PR adds a title to the generated `time` element containing the formatted time, but only while `maxTime` has not passed. 

Like Github does
<img width="282" alt="screenshot 2017-10-07 18 42 59" src="https://user-images.githubusercontent.com/679335/31310393-5ccedc4c-ab8f-11e7-990c-ac7390335376.png">
