### PR TITLE
Do not use computed property in data()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ export const createTimeago = (opts = {}) => {
         const converter = this.converter || opts.converter || defaultConverter
         return converter(
           datetime || this.datetime,
-          locales[this.localeName],
+          locales[this.locale || this.$timeago.locale],
           this.converterOptions || {}
         )
       },


### PR DESCRIPTION
This plugin uses a computed property to infer the `localeName`, which would be fine, except it being used in the `data()` to set the initial value.

This causes the first render of the text to be in english (or default language) and not the configured language, after the first update this is corrected.

Not sure this is the best way :tm: to fix this, but it seemed reasonable enough.

---

Edit: I noticed the `localeName` computed property now only is used in a watcher, which can be removed and used to watch the `locale` prop directly.