### PR TITLE
Fixed: converterOptions as plugin options aren't passed to converter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ export const createTimeago = (opts = {}) => {
         return converter(
           datetime || this.datetime,
           locales[this.locale || this.$timeago.locale],
-          this.converterOptions || {}
+          {...opts.converterOptions,...this.converterOptions}
         )
       },
 


### PR DESCRIPTION
Passed converterOptions object via plugin options now get shallow merged with converterOptions prop and are passed to converter (date-fns)