### PR TITLE
fix: datetime now valid html datetime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ export const createTimeago = (opts = {}) => {
         'time',
         {
           attrs: {
-            datetime: new Date(this.datetime),
+            datetime: new Date(this.datetime).toISOString(),
             title:
               typeof this.title === 'string'
                 ? this.title


### PR DESCRIPTION
Correct HTML invalidation by using ISO 8601 date in the datetime attribute.